### PR TITLE
fix(ios) fix cant find variable UIFontMetrices pre iOS 11

### DIFF
--- a/src/font-scale.ios.ts
+++ b/src/font-scale.ios.ts
@@ -1,5 +1,5 @@
 import { Font, FontWeight } from "tns-core-modules/ui/styling/font";
-
+import { device } from "tns-core-modules/platform"
 import { ButtonCommon, LabelCommon, TabStripItemCommon, labelScaleProperty, buttonScaleProperty, tabStripScaleProperty } from "./font-scale.common";
 
 labelScaleProperty.register(LabelCommon);
@@ -14,6 +14,7 @@ export class Label extends LabelCommon {
             const ios: UILabel = this.ios;
 
             if (!this.scale) return;
+            if (parseInt(device.osVersion) < 11) return;
 
             const newFont = new Font(this.style.fontFamily, this.style.fontSize || 17, null, this.style.fontWeight);
             ios.font = UIFontMetrics.defaultMetrics.scaledFontForFont(newFont.getUIFont(null));
@@ -36,6 +37,7 @@ export class Button extends ButtonCommon {
             const ios: UILabel = btn.titleLabel;
 
             if (!this.scale) return;
+            if (parseInt(device.osVersion) < 11) return;
 
             console.log(this.style.fontSize);
 
@@ -60,6 +62,7 @@ export class TabStripItem extends TabStripItemCommon {
             const item: UITabBarItem = this.nativeView;
 
             if (!this.scale) return;
+            if (parseInt(device.osVersion) < 11) return;
 
             const test: NSDictionary<String, any> = item.titleTextAttributesForState(UIControlState.Normal);
             const font: UIFont = test.valueForKey("NSFont");

--- a/src/font-scale.ios.ts
+++ b/src/font-scale.ios.ts
@@ -1,5 +1,5 @@
 import { Font, FontWeight } from "tns-core-modules/ui/styling/font";
-import { device } from "tns-core-modules/platform"
+import { device } from "tns-core-modules/platform";
 import { ButtonCommon, LabelCommon, TabStripItemCommon, labelScaleProperty, buttonScaleProperty, tabStripScaleProperty } from "./font-scale.common";
 
 labelScaleProperty.register(LabelCommon);


### PR DESCRIPTION
<!--
We, the rest of the NativeScript community, thank you for your
contribution! 
To help the rest of the community review your change, please follow the instructions in the template.
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [x] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.


## What is the current behavior?
Application crashes with `Cant Find Variable: UIFontMetrics`  on devices running iOS that is less than 11.0 due to UIFontMetrics being iOS 11+. 

## What is the new behavior?
Plugin checks to see if OS version is less than 11. If it is, just return.

Fixes/Implements Closes #10 .
